### PR TITLE
Style and automate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: $(addsuffix /handout.pdf,$(wildcard */))
+
+%/handout.pdf: %/handout.tex
+	cd $* && lualatex handout.tex

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+Handouts for ESP32 hacking tasks.
+
+Beware that this is not very well documented.
+To make PDFs:
+
+* `dnf install lualatex`
+* `cd` to the cloned repo
+* `make` to generate PDFs
+  (or `cd basic; lualatex handout.tex` to generate just one)
+* If LaTeX complains about not having `somepackage`,
+  do `dnf install 'tex(somepackage.sty)'`.
+  Repeat until successful.
+  (And improve these instructions with the packages you needed!)

--- a/basic/handout.tex
+++ b/basic/handout.tex
@@ -2,178 +2,132 @@
 % arara: lualatex
 % Typeset using lualatex
 
-\documentclass[a4paper,10pt]{article}
-\usepackage[utf8]{luainputenc}
-\usepackage[pdfborder={0 0 0}]{hyperref}
+\documentclass{../tutorial}
 
-\usepackage[english]{babel}
-
-\usepackage{fouriernc}
-\usepackage{tgpagella}
-\usepackage{xcolor}
-\usepackage[activate=true]{microtype}
-\usepackage{amssymb}
-\usepackage{fontspec}
-\usepackage{titling}
-\usepackage{titlesec}
-
-\usepackage{calc}
-\usepackage{multicol}
-\usepackage{array}
-\usepackage{enumitem}
-\usepackage{tikz}
-\usepackage{siunitx}
-\usepackage{colortbl}
-\usepackage[a4paper,margin=2cm,top=1cm]{geometry}
-
-\setmainfont[Numbers=OldStyle]{TeX Gyre Pagella}
-
-\definecolor{plhome}{HTML}{CCEEFF}
-\definecolor{silver}{HTML}{DDDDDD}
-
-\pagestyle{empty}
-
-\parskip=1ex
-\parindent=0pt
-
-\setlist[enumerate,1]{start=0}
-
-\newcommand\plpage{
-    \newpage
-}
-
-\newcommand\answerspace{\\\rule[0cm]{0pt}{1cm}}
-
-\newcommand\True{\texttt{True}}
-\newcommand\False{\texttt{False}}
-
-\newcommand\startsection[1]{
-     \vspace{0.2ex}
-    \hrule
-    {\fontspec{Oxygen} \tiny
-     \vspace{-1ex}
-     \emph{#1}
-     \vspace{-1.5em}
-    }
-}
-
-\newfontfamily\headingfont[]{Bree Serif}
-\titleformat*{\section}{\LARGE\headingfont}
+\title{System setup for MicroPython \abbr{ESP32} hacking}
 
 \begin{document}
-
-\plpage
-
-\section*{System setup for MicroPython ESP32 hacking}
 
 These instructions are for Fedora.
 Other systems might be different – try your luck!
 
-\section*{Installation}
-
 \begin{enumerate}
 
-\item Open up a terminal and type:
+\section{Installation}
 
-    \texttt{dnf install picocom ampy}
+\item
+    Open up a terminal and type:
+
+    \begin{lstlisting}[language=bash]
+    dnf install picocom ampy
+    \end{lstlisting}
 
     If you're not on Fedora and don't have these packages,
-    \texttt{screen} would do instead of \texttt{picocom},
-    and \texttt{ampy} can be installed via
-    \texttt{python3 -m pip install --user adafruit-ampy}.
+    `screen` would do instead of `picocom`,
+    and `ampy` can be installed via
+    `python3 -m pip install --user adafruit-ampy`.
 
-\item Get yourself to the \texttt{dialout} group.
-      You can use:
+\item
+    Get yourself to the `dialout` group.
+    You can use:
 
-      \texttt{usermod -a -G \$(whoami)}
+    \begin{lstlisting}[language=bash]
+    usermod -a -G $(whoami)
+    \end{lstlisting}
 
-      but make sure to login again after that
-      (e.g. \texttt{su - \$(whoami)}).
-      Verify that you are in the group by running the \texttt{groups} command.
+    but make sure to login again after that
+    (e.g. \lstinline|su - $(whoami)|).
+    Verify that you are in the group by running the `groups` command.
 
-    \textit{
-      The \texttt{dialout} group is historically designed for modems
-      and gives you full and direct access to serial ports.
-    }
+    \begin{comment}
+        The `dialout` group is historically designed for modems
+        and gives you full and direct access to serial ports.
+    \end{comment}
 
-\item You need drivers for the on-board CP2102 USB-serial adapter.
+\item
+    You need drivers for the on-board \abbr{CP2102} \abbr{USB}-serial adapter.
     If you are using Linux, you have them.
-      If you are not using Linux, may the force be with you
-      (ask booth attendants for help).
+    If you are not using Linux, may the force be with you
+    (ask booth attendants for help).
 
-\end{enumerate}
+\section{Talking to the board}
 
+    \begin{comment}
+        To protect delicate pins and make connections easier,
+        the black \abbr{ESP32} devkit is plugged into a white OctopusLab Robot~Board.
+        Please ask if you want to unplug it.
+    \end{comment}
 
-\section*{Talking to the board}
+\item
+    Connect the \abbr{ESP32} board via an \abbr{USB} cable.
+    Sometimes, the cable or even the board can be faulty,
+    use `dmesg | tail` to verify your system can actually see the board.
+    Ask for help if it doesn't.
 
-\textit{
-    To protect delicate pins and make connections easier,
-    the black ESP32 devkit is plugged into the white OctopusLab Robot~Board.
-    Please ask if you want to unplug it.
-}
+\item
+    Use \texttt{picocom} to get the interactive interpreter.
+    The full command is:
 
-\begin{enumerate}[resume]
+    \begin{lstlisting}[language=bash]
+    picocom -b 115200 --flow n /dev/ttyUSB0
+    \end{lstlisting}
 
-\item Connect the ESP32 board via an USB cable.
-      Sometimes, the cable or even the board can be faulty,
-      use \texttt{dmesg | tail} to verify your system can actually see the board.
-      Ask for help if it doesn't.
+    The first number specifies the baud rate -- a speed of communication over serial line.
+    All our \abbr{ESP32} boards communicate using this baud rate.
+    We disable the flow control of the serial-port.
+    That should be the default,
+    but explicit is better than implicit.
 
-\item Use \texttt{picocom} to get the interactive interpreter.
-      The full command is:
+    Lastly, we connect to `/dev/ttyUSB0`.
+    That's the file representing our device (or the serial line to it).
+    The filename may be different, consult the `dmesg | tail` output.
 
-      \texttt{picocom -b 115200 --flow n /dev/ttyUSB0}.
+    If you need to use `screen`,
+    the command is `screen /dev/ttyUSB0 115200`.
 
-      The first number specifies the baud rate -- a speed of communication over serial line.
-      All our ESP32 boards communicate using this baud rate.
-      We disable the flow control of the serial-port.
-      That should be the default,
-      but explicit is better than implicit.
+\item
+    You should see `Terminal ready`.
+    Pres Enter and the MicroPython's interactive prompt with `>>>` should appear.
+    If you see wall of random characters instead,
+    locate and press the `EN` button on the device
+    (it's near the USB port).
 
-      Lastly, we connect to \texttt{/dev/ttyUSB0}.
-      That's the file representing our device (or the serial line to it).
-      The filename may be different, consult the \texttt{dmesg | tail} output.
+\item
+    Experiment with the interactive Python prompt. Is it Python?
+    Can you `print` stuff? Is something missing?
 
-      If you need to use \texttt{screen},
-      the command is \texttt{screen /dev/ttyUSB0 115200}.
+    If you prefer to code in your favorite text editor,
+    you can use \kbd{Ctrl}+\kbd{e} to activate the \emph{paste mode}.
 
-\item You should see \texttt{Terminal ready}.
-      Pres Enter and the MicroPython's interactive prompt with \texttt{>>>} should appear.
-      If you see wall of random characters instead,
-      locate and press the \emph{EN} button on the device
-      (it's near the USB port).
+\item
+    To exit `picocom`, hold the \kbd{Ctrl} key, press \kbd{a},
+    then \kbd{q} and lift the \kbd{Ctrl} key.
+    Alternatively, unplug the board.
 
-\item Experiment with the interactive Python prompt. Is it Python?
-      Can you \texttt{print} stuff? Is something missing?
+\section{The board's filesystem}
 
-      If you prefer to code in your favorite text editor,
-      you can use \texttt{Ctrl+e} to activate the \emph{paste mode}.
+\item
+    The board has a simple filesystem.
+    To execute a file on the board when the board starts,
+    write a program on your computer and save it as `main.py`.
+    Use `ampy` to put the file into the board:
 
-\item To exit \texttt{picocom}, hold the \texttt{Ctrl} key, press \texttt{a},
-      then \texttt{q} and lift the \texttt{Ctrl} key.
-      Alternatively, unplug the board.
+    \begin{lstlisting}[language=bash]
+    ampy -p /dev/ttyUSB0 put main.py
+    \end{lstlisting}
 
-\end{enumerate}
+    Connect via `picocom`, then press the \emph{EN} button to see
+    what is happening. Use \kbd{Ctrl}+\kbd{c} to interrupt a running program.
+    Use \lstinline[emph=rm]|ampy -p /dev/ttyUSB0 rm main.py|
+    to get rid of the file.
+    Explore `ampy --help` to see what else is possible.
 
-\section*{The board's filesystem}
+\item
+    Congratulations, you've made it! Now you are ready to pick a task.
 
-\begin{enumerate}[resume]
-
-\item The board has a simple filesystem.
-      To execute a file on the board when the board starts,
-      write a program on your computer and save it as \texttt{main.py}.
-      Use \texttt{ampy -p /dev/ttyUSB0 put main.py} to put the file into the board.
-
-      Connect via \texttt{picocom}, then press the \emph{EN} button to see
-      what is happening. Use \texttt{Ctrl+c} to interrupt a running program.
-      Use \texttt{ampy -p /dev/ttyUSB0 rm main.py} to get rid of the file.
-      Explore \texttt{ampy --help} to see what else is possible.
-
-\item Congratulations, you've made it! Now you are ready to pick a task.
-
-    \textit{
-    Don't forget to ask for stickers as a reward for your efforts!
-    }
+    \begin{comment}
+        Don't forget to ask for stickers as a reward for your efforts!
+    \end{comment}
 
 \end{enumerate}
 

--- a/blink/handout.tex
+++ b/blink/handout.tex
@@ -2,195 +2,155 @@
 % arara: lualatex
 % Typeset using lualatex
 
-\documentclass[a4paper,10pt]{article}
-\usepackage[utf8]{luainputenc}
-\usepackage[pdfborder={0 0 0}]{hyperref}
+\documentclass{../tutorial}
 
-\usepackage[english]{babel}
-
-\usepackage{fouriernc}
-\usepackage{tgpagella}
-\usepackage{xcolor}
-\usepackage[activate=true]{microtype}
-\usepackage{amssymb}
-\usepackage{fontspec}
-\usepackage{titling}
-\usepackage{titlesec}
-
-\usepackage{calc}
-\usepackage{multicol}
-\usepackage{array}
-\usepackage{enumitem}
-\usepackage{tikz}
-\usepackage{pgfplots}
-\usepackage{siunitx}
-\usepackage{colortbl}
-\usepackage[a4paper,margin=2cm,top=1cm]{geometry}
-
-\setmainfont[Numbers=OldStyle]{TeX Gyre Pagella}
-
-\definecolor{plhome}{HTML}{CCEEFF}
-\definecolor{silver}{HTML}{DDDDDD}
-
-\pagestyle{empty}
-
-\parskip=1ex
-\parindent=0pt
-
-\setlist[enumerate,1]{start=0}
-
-\newcommand\answerspace{\\\rule[0cm]{0pt}{1cm}}
-
-\newcommand\True{\texttt{True}}
-\newcommand\False{\texttt{False}}
-
-\newcommand\startsection[1]{
-     \vspace{0.2ex}
-    \hrule
-    {\fontspec{Oxygen} \tiny
-     \vspace{-1ex}
-     \emph{#1}
-     \vspace{-1.5em}
-    }
-}
-
-\newfontfamily\headingfont[]{Bree Serif}
-\titleformat*{\section}{\LARGE\headingfont}
+\title{Blinking LED with MicroPython on \abbr{ESP32}}
 
 \begin{document}
-
-\section*{Blinking LED with MicroPython on ESP32}
-
 \begin{enumerate}
-\item Set up your environment. Ask booth staff for the proper handout.
 
-\end{enumerate}
+\item
+    Set up your environment. Ask booth staff for the proper handout.
 
-\section*{Controlling the LED}
+\section{Controlling the LED}
 
-\begin{enumerate}[resume]
+\item
+    MicroPython allows you to control the microcontroller's \emph{pins},
+    to which other devices are connected.
+    To do that, you need to import the `Pin` class with:
 
-\item MicroPython allows you to control the microcontroller's \emph{pins},
-      to which other devices are connected.
-      To do that, you need to import the \texttt{Pin} class with:
+    \begin{lstlisting}
+    from machine import Pin
+    \end{lstlisting}
 
-      \texttt{from machine import Pin}.
+\item
+    A pin can serve as a binary input/output.
+    On the hardware side, imagine there either is electricity or there isn't.
+    On the software side, you can either read `0` or `1` from an
+    input pin, or write `0` or `1` to an output pin.
 
-\item A pin can serve as a binary input/output.
-      On the hardware side, imagine there either is electricity or there isn't.
-      On the software side, you can either read \texttt{0} or \texttt{1} from an
-      input pin, or write \texttt{0} or \texttt{1} to an output pin.
+    Create an output Pin object for the integrated LED (\emph{Light Emitting Diode}),
+    which is connected to pin \#2, and save it in a variable:
 
-      Create an output Pin object for the integrated LED (\emph{Light Emitting Diode}),
-      which is connected to pin \#2, and save it in a variable:
+    \begin{lstlisting}
+    led = Pin(2, Pin.OUT)
+    \end{lstlisting}
 
-      \texttt{led = Pin(2, Pin.OUT)}
+\item
+    Write 1 or 0 to turn the light on or off:
 
-\item Write 1 or 0 to turn the light on or off:
+    \begin{lstlisting}
+    led.value(1)
+    led.value(0)
+    \end{lstlisting}
 
-    \texttt{
-        led.value(1) \\
-        led.value(0)
-    }
+\section{Blinking the LED with a button}
 
-\end{enumerate}
+\item
+    Let's create a program that turns the LED on when the user is holding a button.
+    We'll use the integrated \emph{BOOT} button, which is connected to pin number 0.
+    Create an input Pin for it:
 
-\section*{Blinking the LED with a button}
+    \begin{lstlisting}
+    button = Pin(0, Pin.IN)
+    \end{lstlisting}
 
-\begin{enumerate}[resume]
+\item
+    Read the value. What is it?
 
-\item Let's create a program that turns the LED on when the user is holding a button.
-      We'll use the integrated \emph{BOOT} button, which is connected to pin number 0.
-      Create an input Pin for it:
+    \begin{lstlisting}
+    button.value()
+    \end{lstlisting}
 
-      \texttt{~~~~button = Pin(0, Pin.IN)}
+\item
+    Read the value while holding the \emph{BOOT} button. What is it?
 
-\item Read the value with \texttt{button.value()}. What is it?
-
-\item Read the value while holding the \emph{BOOT} button. What is it?
-
-    \textit{
+    \begin{comment}
         The \emph{BOOT} button is next to the USB connector.
         Don't confuse it with \emph{EN}!
-    }
+    \end{comment}
 
-\item Using an infinite loop, make the LED shine if and only if you hold the button.
+\item
+    Using an infinite loop, make the LED shine if and only if you hold the button.
 
-\item Change the program so one press of the button switches the light.
-      Is there a problem? How can you check for one press?
+\item
+    Change the program so one press of the button switches the light.
+    Is there a problem? How can you check for one press?
 
-\end{enumerate}
+\section{Blinking the LED with sleep}
 
-\section*{Blinking the LED with sleep}
-
-\begin{enumerate}[resume]
-
-\item Try out the \texttt{sleep} function form the \texttt{time} module.
+\item
+    Try out the `sleep` function form the `time` module.
     What does it do?
 
-    \texttt{
-        from time import sleep \\
-        sleep(1/2)
-    }
+    \begin{lstlisting}
+    from time import sleep
+    sleep(1/2)
+    \end{lstlisting}
 
-\item Make the LED blink 10 times with a half-second interval.
+\item
+    Make the LED blink 10 times with a half-second interval.
+
+\section{Blinking with Pulse Width Modulation}
+
+\item
+    Make the LED blink really fast.
+    On for $\frac{1}{1000}$ of a second, off for $\frac{2}{1000}$ of a second.
+    What happens? What if you swap the numbers?
+    This is how light intensity is usually controlled: with fast blinking.
+
+\item
+    Fast blinking with sleep is not very effective.
+    You can use the integrated hardware \emph{Pulse Width Modulation} (PWM) instead.
+    Imagine a rectangular wave as drawn here:
+
+    % https://tex.stackexchange.com/a/113050/51382
+    \begin{figure}[h]
+        \centering
+        \begin{tikzpicture}
+            \begin{axis}[
+                width=.6\textwidth,
+                height=.2\textwidth,
+                x axis line style={-stealth},
+                y axis line style={-stealth},
+                ymax = 1.2, xmax=15,
+                axis lines*=center,
+                ytick={0},
+                xtick={0},
+                xticklabels={},
+                xlabel={Time $\rightarrow$},
+                ylabel={Value},
+                xlabel near ticks,
+                ylabel near ticks
+            ]
+                \addplot+[thick,mark=none,const plot]
+                coordinates {
+                    (0,0) (0,1) (2,0) (3,1) (5,0) (6,1) (8,0) (9,1) (11,0)
+                    (12,1) (14,0)
+                };
+            \end{axis}
+        \end{tikzpicture}
+    \end{figure}
+
+    A PWM will change the value of a pin from 0 to 1 and back in a periodic interval.
+    The `PWM` class from the `machine` module takes 3 arguments:
+    a pin, frequency and the duty cycle.
+
+    \begin{lstlisting}
+        pwm = PWM(led, freq=50, duty=512)
+    \end{lstlisting}
+
+    Frequency determines how fast the LED will blink.
+    Duty determines the proportion of time where the LED is on: 0 means never;
+    1023 means always.
+    When experimenting, mind the fact that humans don't perceive light intensity linearly.
+
+    With a PWM running, you can do other things in Python -- it is not blocking.
+    To change a PWM's frequency or duty, use the `pwm.freq(...)`
+    or `pwm.duty(...)` methods.
+    To stop a PWM, use `pwm.deinit()`.
+
+    Try it out!
 
 \end{enumerate}
-
-\section*{Blinking with Pulse Width Modulation}
-
-\begin{enumerate}[resume]
-
-\item Make the LED blink really fast.
-      On for $\frac{1}{1000}$ of a second, off for $\frac{2}{1000}$ of a second.
-      What happens? What if you swap the numbers?
-      This is how light intensity is usually controlled: with fast blinking.
-
-\item Fast blinking with sleep is not very effective.
-      You can use the integrated hardware \emph{Pulse Width Modulation} (PWM) instead.
-      Imagine a rectangular wave as drawn here:
-
-      % https://tex.stackexchange.com/a/113050/51382
-      \begin{center}
-      \begin{tikzpicture}
-      \begin{axis}[
-      width=.6\textwidth,
-      height=.2\textwidth,
-      x axis line style={-stealth},
-      y axis line style={-stealth},
-      ymax = 1.2, xmax=15,
-      axis lines*=center,
-      ytick={0},
-      xtick={0},
-      xticklabels={},
-      xlabel={Time $\rightarrow$},
-      ylabel={Value},
-      xlabel near ticks,
-      ylabel near ticks]
-      \addplot+[thick,mark=none,const plot]
-      coordinates
-      {(0,0) (0,1) (2,0) (3,1) (5,0) (6,1) (8,0) (9,1) (11,0) (12,1) (14,0)};
-      \end{axis}
-      \end{tikzpicture}
-      \end{center}
-
-      A PWM will change the value of a pin from 0 to 1 and back in a periodic interval.
-      The \texttt{PWM} class from the \texttt{machine} module takes 3 arguments:
-      a pin, frequency and the duty cycle.
-
-      \texttt{~~~~pwm = PWM(led, freq=50, duty=512)}
-
-      Frequency determines how fast the LED will blink.
-      Duty determines the proportion of time where the LED is on: 0 means never;
-      1023 means always.
-      When experimenting, mind the fact that humans don't perceive light intensity linearly.
-
-      With a PWM running, you can do other things in Python -- it is not blocking.
-      To change a PWM's frequency or duty, use the \texttt{pwm.freq(...)} or \texttt{pwm.duty(...)} methods.
-      To stop a PWM, use \texttt{pwm.deinit()}.
-
-      Try it out!
-
-\end{enumerate}
-
 \end{document}

--- a/tutorial.cls
+++ b/tutorial.cls
@@ -1,0 +1,78 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{tutorial}[2018/01/21 HW tutorial]
+
+\LoadClass[a4paper,8pt]{article}
+
+% Language
+\usepackage[utf8]{luainputenc}
+\usepackage[pdfborder={0 0 0}]{hyperref}  % needs to be early-ish
+\usepackage[english]{babel}
+
+% Fonts
+\usepackage{fouriernc}
+\usepackage{tgpagella}
+\usepackage{xcolor}
+\usepackage{amssymb}
+\usepackage{fontspec}
+\setmainfont[Numbers=OldStyle]{TeX Gyre Pagella}
+
+% Page layout
+\usepackage[activate=true]{microtype}
+\usepackage[a4paper,margin=2cm,top=1cm]{geometry}
+\pagestyle{empty}
+\parskip=1ex
+\parindent=0pt
+
+% Charts & Math
+\usepackage{calc}
+\usepackage{tikz}
+\usepackage{pgfplots}
+\usepackage{siunitx}
+\usepackage{colortbl}
+
+% Lists (tasks)
+\usepackage{enumitem}
+\setlist[enumerate,1]{start=0,leftmargin=0pt,labelindent=0pt,itemindent=0pt,resume}
+
+% Headings
+\usepackage{titling}
+\usepackage{titlesec}
+\newfontfamily\headingfont[]{Bree Serif}
+\titleformat*{\section}{\large\headingfont}
+\titlespacing*{\section}{0pt}{5pt plus 5pt}{0pt}
+% Remove section numbers
+\let\oldsection\section
+\renewcommand\section{\oldsection*} 
+
+% Code listings
+\usepackage{listings}
+\lstset{
+    language=Python,
+    basicstyle=\small\ttfamily,
+    tabsize=4,
+    columns=fixed,
+    showstringspaces=false,
+    showtabs=false,
+    keepspaces,
+    keywordstyle=\bfseries,
+    firstnumber=last,
+    emphstyle=\bfseries,
+    showlines=false,
+    texcl=true,
+    escapebegin=\rmfamily,
+    gobble=4,  % All code listings must be indented 4 spaces!
+    backgroundcolor=\color{black!10!white},
+    frame=single,
+    framerule=0pt,
+}
+
+% Additional commands
+\newenvironment{comment}{\itshape}{}
+\newcommand\kbd[1]{\texttt{#1}}
+\newcommand\abbr[1]{{\addfontfeature{Numbers=Lining}#1}}
+
+% Title, ` character for inline code
+\AtBeginDocument{
+    {\headingfont\Large\thetitle}
+    \lstMakeShortInline[framerule=1pt]`
+}


### PR DESCRIPTION
* `make` re-runs lualatex on changed `handout.tex` in all directories
* TeX code for style (vs. substance) is now in a shared class file
  * New commands `\begin{lstlisting}` (code listing), `\begin{comment}`, `\title`, `\abbr`eviation, `\kbd`,\lstinline|...|` for inline code with Markdown-like <code>\`…\`</code> shorthand, `\section` without star.
* Tiny README

While changing this, I re-indented the sources to 4 spaces – before realizing this will probably cause conflicts. If it does, sorry! I'll be happy to merge any changes.
(My editor doesn't like 6-space indentation, and I support its decision.)

While re-styling, I also made sure required code is in block code listings (not inline).